### PR TITLE
PSQLADM-460 docs:rename pages to align

### DIFF
--- a/docs/2.4.4-1.2.md
+++ b/docs/2.4.4-1.2.md
@@ -19,7 +19,7 @@
 
 | Release date | November 08, 2022 |
 |---|---|
-| Install instructions | [ProxySQL and proxysql-admin](https://docs.percona.com/proxysql/install-v2.htm) |
+| Install instructions | [ProxySQL and proxysql-admin](https://docs.percona.com/proxysql/install-v2.html) |
 | Download this version | [ProxySQL 2.x](https://www.percona.com/downloads/proxysql2/) |
 
 [ProxySQL](https://proxysql.com/) is a high-performance proxy for MySQL and MySQL-compatible database servers such as Percona Server for MySQL and MariaDB. It acts as an intermediary for client requests seeking resources from the database. ProxySQL was created for the database administrator as a solution for complex replication topology issues. 

--- a/docs/2.4.7.md
+++ b/docs/2.4.7.md
@@ -2,7 +2,7 @@
 
 | Release date | February 14, 2023 |
 |---|---|
-| Install instructions | [ProxySQL and proxysql-admin](https://docs.percona.com/proxysql/install-v2.htm) |
+| Install instructions | [ProxySQL and proxysql-admin](https://docs.percona.com/proxysql/install-v2.html) |
 | Download this version | [ProxySQL 2.x](https://www.percona.com/downloads/proxysql2/) |
 
 [ProxySQL](https://proxysql.com/) is a high-performance proxy for MySQL and MySQL-compatible database servers such as Percona Server for MySQL and MariaDB. It acts as an intermediary for client requests seeking resources from the database. ProxySQL was created for the database administrator as a solution for complex replication topology issues. 

--- a/docs/build-psh.md
+++ b/docs/build-psh.md
@@ -1,12 +1,12 @@
-# Build the Percona Scheduler admin tool
+# Build the pxc_scheduler_handler tool
 
-The Percona Scheduler Admin has two main files: the `pxc_scheduler_handler` binary and the `percona_scheduler_admin` script.
+The pxc_scheduler_handler tool has two main files: the `pxc_scheduler_handler` binary and the `percona_scheduler_admin` script.
 
 The `pxc_scheduler_handler` does the following tasks:
 
-* Monitors the cluster’s health
+* Monitors the cluster health
 
-* Processes the cluster’s state and evaluates the scenario
+* Processes the cluster state and evaluates the scenario
 
 * Performs actions, such as failover in case of an incident
 
@@ -53,5 +53,5 @@ mysql> GRANT ALL PRIVILEGES ON *.* TO 'admin'@'192.%' WITH GRANT OPTION;
 
 !!! admonition "See also"
     
-    [Log file or lock file locations](percona-scheduler-admin-known-limitations.md#do-not-place-the-log-file-or-lock-file-in-the-home-directory)
+    [Log file or lock file locations](psh-known-limitations.md#do-not-place-the-log-file-or-lock-file-in-the-home-directory)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,5 +23,5 @@ ProxySQL is available from the Percona software repositories with the following:
 
     * [ProxySQL Admin (proxysql-admin)](proxysql-admin-tool-v2-config.md) simplifies the configuration of *Percona XtraDB Cluster* nodes with ProxySQL.
 
-    * [Percona Scheduler Admin (percona-scheduler-admin)](build-percona-scheduler-admin.md) can automatically perform a failover due to node failures, service degradation, or maintenance. This utility is available from [ProxySQL 2.3.2-1.2](./release-notes-2.3.2-1.md) and higher.
+    * [pxc_scheduler_handler](build-psh.md) can automatically perform a failover due to node failures, service degradation, or maintenance. This utility is available from [ProxySQL 2.3.2-1.2](./release-notes-2.3.2-1.md) and higher.
 

--- a/docs/install-v2.md
+++ b/docs/install-v2.md
@@ -60,7 +60,7 @@ Select the same package installer used to install [Percona XtraDB Cluster](https
         ...
         ```
 
-## Verify the Percona_Scheduler_Admin utility installation
+## Verify the pxc_scheduler_handler installation
 
 If you have installed [ProxySQL 2.3.2-2.1](release-notes-2.3.2-1.md) or later, verify the Percona_Scheduler_Admin installation with the following command:
 
@@ -68,7 +68,7 @@ If you have installed [ProxySQL 2.3.2-2.1](release-notes-2.3.2-1.md) or later, v
 $ percona-scheduler-admin --debug
 ```
 
-Running this command without the [Percona Scheduler configuration file](percona-scheduler-admin-configuration.md) generates an error.
+Running this command without the [pxc_scheduler_handler configuration file](psh-configuration.md) generates an error.
 
 ??? example "Error message"
 

--- a/docs/psh-configuration.md
+++ b/docs/psh-configuration.md
@@ -1,10 +1,10 @@
-# Percona Scheduler Admin configuration
+# pxc-scheduler-handler configuration
 
-*ProxySQL* with the `percona-scheduler-admin` stores the parameters in a
+*ProxySQL* with the `pxc-scheduler-handler` stores the parameters in a
 configuration file that uses the toml format. This file defines
 the server credentials and other settings.
 
-Use the `--config-file` option to run the *percona-scheduler-admin* script.
+Use the `--config-file` option to run the pxc-scheduler-handler script.
 
 !!! warning
 
@@ -12,7 +12,7 @@ Use the `--config-file` option to run the *percona-scheduler-admin* script.
 
 ## Example of a configuration file
 
-A configuration file is used to control the Percona Scheduler Admin operations. The file can be changed as needed. The administrator controls what protected resources the tool can access. 
+A configuration file is used to control the `pxc-scheduler-handler` operations. The file can be changed as needed. The administrator controls what protected resources the tool can access. 
 
 ```{.text .no-copy}
 # For the detailed manual, see

--- a/docs/psh-detailed-options.md
+++ b/docs/psh-detailed-options.md
@@ -1,6 +1,6 @@
-# Percona Scheduler Admin options
+# pxc-scheduler-handler options
 
-The Percona Scheduler Admin script lists the available options in the Percona Scheduler Admin configuration file. The following options are described in more detail:
+The pxc_scheduler_handler script lists the available options in the pxc_scheduler_handler configuration file. The following options are described in more detail:
 
 | Option Name                                             |
 |---------------------------------------------------------|
@@ -106,10 +106,10 @@ For example, in a three-node cluster, assign a `900` to the writer node and
 
 This option does these operations automatically without any manual intervention.
 
-Review [do not combine certain options](./percona-scheduler-admin-known-limitations.md#do-not-combine-certain-options).
+Review [do not combine certain options](./psh-known-limitations.md#do-not-combine-certain-options).
 
 The following example is a default configuration when the
-`percona-scheduler-admin` sets up proxysql.
+`pxc_scheduler_handler` sets up proxysql.
 
 ??? example "Expected output"
 
@@ -164,7 +164,7 @@ $ percona-scheduler-admin --config-file=config.toml --update-cluster --auto-assi
 
 ## --config-file
 
-This option reads the login credentials from a configuration file. Command-line options override configuration file values. For more information, see [Percona Scheduler Admin configuration](./percona-scheduler-admin-configuration.md).
+This option reads the login credentials from a configuration file. Command-line options override configuration file values. For more information, see [pxc_scheduler_handler configuration](./psh-configuration.md).
 
 ## --debug
 
@@ -191,7 +191,7 @@ $ percona-scheduler-admin --config-file=config.toml --disable
 ## --disable_updates
 
 This option can be used with any command to disable updating the 
-Percona Scheduler admin checksum for the `mysql_query_rules`, 
+pxc_scheduler_handler checksum for the `mysql_query_rules`, 
 `mysql_server` and `mysql_users` tables. The option avoids updates in 
 those tables for one node from being propagated to the cluster.
 
@@ -466,7 +466,7 @@ This option displays the help text.
 
 ## –-is-enabled
 
-This option checks if `percona-scheduler-admin` configured the hostgroups in ProxySQL.
+This option checks if `pxc_scheduler_handler` configured the hostgroups in ProxySQL.
 
 Returns a zero (0) if an entry corresponds to the writer hostgroup and is set to active in ProxySQL.
 
@@ -486,7 +486,7 @@ $ percona-scheduler-admin --config-file=config.toml --is-enabled
 
 ### --is-enabled verification example
 
-Verify if `percona-scheduler-admin` configured the hostgroups in ProxySQL.
+Verify if `pxc_scheduler_handler` configured the hostgroups in ProxySQL.
 
 ```{.bash data-prompt="$"}
 $ echo $?
@@ -538,7 +538,7 @@ all servers belonging to the current cluster before running the [--update-cluste
 
 ```{.bash data-prompt="$"}
 $ percona-scheduler-admin --config-file=config.toml 
---remove-all-servers --udpate-cluster
+--remove-all-servers --update-cluster
 ```
 
 ## –-server
@@ -757,7 +757,7 @@ or Internet Protocol version 6 (IPv6).
 $ percona-scheduler-admin --config-file=config.toml --update-cluster --update-read-weight="<IP_ADDRESS:PORT>, <New Weight>"
 ```
 
-The following table displays the `percona-scheduler-admin` default configuration for *ProxySQL*.
+The following table displays the `pxc_scheduler_handler` default configuration for *ProxySQL*.
 
 ```{.text .no-copy}
 Cluster node info
@@ -826,7 +826,7 @@ or Internet Protocol version 6 (IPv6).
 $ percona-scheduler-admin --config-file=config.toml --update-cluster --update-write-weight="<IP_ADDRESS:PORT>, <New Weight>"
 ```
 
-The following table displays the `percona-scheduler-admin` default configuration for  *ProxySQL*.
+The following table displays the `pxc-scheduler-handler` default configuration for  *ProxySQL*.
 
 ```{.text .no-copy}
 Cluster node info

--- a/docs/psh-known-limitations.md
+++ b/docs/psh-known-limitations.md
@@ -1,16 +1,16 @@
-# Known issues in Percona Scheduler Admin
+# Known issues in pxc_scheduler_handler
 
-This document lists the known issues in the Percona Scheduler Admin.
+This document lists the known issues in the pxc_scheduler_handler.
 
 ## Do not combine certain options
 
 The following options are mutually exclusive. An attempt to combine these options in a command creates in an error and no action is taken.
 
-* [-–update-write-weight](./percona-scheduler-admin-options-detail.md#-update-write-weight) and [-–auto-assign-weights](./percona-scheduler-admin-options-detail.md#-auto-assign-weights)
+* [-–update-write-weight](./psh-detailed-options.md#-update-write-weight) and [-–auto-assign-weights](./psh-detailed-options.md#-auto-assign-weights)
 
-* [-–write-node](./percona-scheduler-admin-options-detail.md#-write-node) and [-–auto-assign-weights](./percona-scheduler-admin-options-detail.md#-auto-assign-weights)
+* [-–write-node](./psh-detailed-options.md#-write-node) and [-–auto-assign-weights](./psh-detailed-options.md#-auto-assign-weights)
 
-* [-–write-node](./percona-scheduler-admin-options-detail.md#-write-node) and [-–update-write-weight](./percona-scheduler-admin-options-detail.md#-update-write-weight)
+* [-–write-node](./psh-detailed-options.md#-write-node) and [-–update-write-weight](./psh-detailed-options.md#-update-write-weight)
 
 ## Do not place the log file or lock file in the Home directory
 

--- a/docs/psh-options.md
+++ b/docs/psh-options.md
@@ -1,10 +1,10 @@
-# Percona Scheduler Admin statements
+# pxc_scheduler_handler statements
 
 ## Statement reference
 
-The standard percona-scheduler-admin statement includes
+The standard pxc_scheduler_handler statement includes
 `percona-scheduler-admin --config-file=<configuration file name and
-extension>`. A Percona Scheduler Admin example statement has the following syntax:
+extension>`. A pxc_scheduler_handler example statement has the following syntax:
 
 ```{.text .no-copy}
 percona-scheduler-admin --config-file=config.toml [option] [option]
@@ -17,9 +17,9 @@ $ percona-scheduler-admin --debug
 ERROR : The --config-file option is required but is missing from the command.
 ```
 
-The options determine what the statement does. The percona-scheduler-admin statement must include at least one option. A command without an option returns an error and nothing happens.
+The options determine what the statement does. The pxc_scheduler_handler statement must include at least one option. A command without an option returns an error and nothing happens.
 
-For most options, two hyphens (--) precede an option name. The [disable](./percona-scheduler-admin-options-detail.md#-disable---d) and the [enable](./percona-scheduler-admin-options-detail.md#–enable---e) option can be selected with one hyphen (-) and the appropriate abbreviation.
+For most options, two hyphens (--) precede an option name. The [disable](./psh-detailed-options.md#-disable---d) and the [enable](./psh-detailed-options.md#–enable---e) option can be selected with one hyphen (-) and the appropriate abbreviation.
 
 For example, the following commands return the same result:
 
@@ -29,7 +29,7 @@ $ percona-scheduler-admin --config-file=config.toml -e
 $ percona-scheduler-admin --config-file=config.toml --enable
 ```
 
-You can combine some options with other, optional options to modify the statement’s behavior. Multiple options are separated by a space. You can combine the options in any order.
+You can combine some options with other, optional options to modify the statement behavior. Multiple options are separated by a space. You can combine the options in any order.
 
 An example of combining options in one statement:
 
@@ -63,4 +63,4 @@ Specific options, such as -–write-node or –-server, require a value.
 $> percona-scheduler-admin --config-file=config.toml --server=192.168.56.32:3306
 ```
 
-For the available options, see [Percona Scheduler Admin options](percona-scheduler-admin-options-detail.md)
+For the available options, see [pxc_scheduler_handler options](psh-detailed-options.md)

--- a/docs/psh-overview.md
+++ b/docs/psh-overview.md
@@ -1,6 +1,6 @@
-# ProxySQL 2.x.x and Percona Scheduler Admin tool
+# ProxySQL 2.x.x and pxc_scheduler_handler tool
 
-[*ProxySQL* 2.3.2-1.2](release-notes-2.3.2-1.md) adds the Percona Scheduler Admin (percona-scheduler-admin) tool. This tool has a segment-aware failover mechanism and can automatically perform a failover due to node failures, service degradation, or maintenance requirements. The external scheduler has the following qualities:
+[*ProxySQL* 2.3.2-1.2](release-notes-2.3.2-1.md) adds the pxc_scheduler_handler tool. This tool has a segment-aware failover mechanism and can automatically perform a failover due to node failures, service degradation, or maintenance requirements. The external scheduler has the following qualities:
 
 * Capable of parallel query execution on nodes which results in faster failover or fallback
 
@@ -16,11 +16,11 @@
 
 !!! important
 
-    Percona Scheduler Admin was built for a different purpose and has different features than [proxy-admin](proxysql-admin-tool-v2-config.md). You cannot use the options from one admin tool in the other admin tool. Combining the options causes unintended results.
+    pxc_scheduler_handler was built for a different purpose and has different features than [proxy-admin](proxysql-admin-tool-v2-config.md). You cannot use the options from one admin tool in the other admin tool. Combining the options causes unintended results.
 
 ## Version changes
 
-The Percona Scheduler Admin tool has been tested with ProxySQL 2.3.0, 2.3.2-1.2, and later versions.
+The pxc_scheduler_handler tool has been tested with ProxySQL 2.3.0, 2.3.2-1.2, and later versions.
 
 [*ProxySQL* 2.4.2](2.4.2.md) add the following checks:
 
@@ -40,15 +40,15 @@ The Percona Scheduler Admin tool has been tested with ProxySQL 2.3.0, 2.3.2-1.2,
 
 ## Prerequisites
 
-The following are the prerequisites for using the Percona Scheduler Admin:
+The following are the prerequisites for using the pxc_scheduler_handler:
 
 * The [mysql command-line client](https://dev.mysql.com/doc/refman/8.0/en/mysql.html) and [my_print_defaults](https://dev.mysql.com/doc/refman/8.0/en/my-print-defaults.html) must be installed on the system. Install the server packages on the system to add these tools.
 
 * *ProxySQL* and *Percona XtraDB Cluster* are running.
 
-For information on the Percona Scheduler Admin tool installation, see [Install ProxySQL 2.x.x and the admin utilities](install-v2.md) or [Build the Percona Scheduler admin tool](build-percona-scheduler-admin.md).
+For information on the pxc_scheduler_handler tool installation, see [Install ProxySQL 2.x.x and the admin utilities](install-v2.md) or [Build the pxc_scheduler_handler tool](build-psh.md).
 
 ## Add an issue
 
-If you find a Percona Scheduler Admin bug, add a bug report in the [PSQLADM project](https://jira.percona.com/projects/PSQLADM).
+If you find a pxc_scheduler_handler bug, add a bug report in the [PSQLADM project](https://jira.percona.com/projects/PSQLADM).
 

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -128,7 +128,7 @@ extra:
 
 nav:
   - Home: index.md
-  - ProxySQL 1.x.x and the proxysql-admin tool:
+  - ProxySQL 1.x.x and the proxysql-admin:
       - proxysql-v1.md
       - installing-v1.md
       - tarball-v1.md
@@ -138,23 +138,23 @@ nav:
         - where-to-download-proxysql.md
         - install-v2.md
         - install-proxysql2-tarball.md
-        - build-percona-scheduler-admin.md
+        - build-psh.md
       - Deploy:
         - start-or-stop-proxysql2.md
         - upgrade-proxysql2.md
         - uninstall-proxysql2.md
-      - proxysql-admin tool:
+      - proxysql-admin:
         - Manage:
           - proxysql-admin-tool-changes.md
           - proxysql-admin-tool-v2-config.md
           - proxysql-admin-tool-functions.md
-      - pxc_scheduler_handler tool:
+      - pxc_scheduler_handler:
         - Manage:
-          - percona-scheduler-admin.md
-          - percona-scheduler-admin-configuration.md
-          - percona-scheduler-admin-statements-options.md
-          - percona-scheduler-admin-options-detail.md
-          - percona-scheduler-admin-known-limitations.md
+          - psh-overview.md
+          - psh-configuration.md
+          - psh-options.md
+          - psh-detailed-options.md
+          - psh-known-limitations.md
   - Release notes:
       - Release notes index: release-notes.md
       - 2.4.7.md


### PR DESCRIPTION
	renamed:    docs/build-percona-scheduler-admin.md -> docs/build-psh.md
	renamed:    docs/percona-scheduler-admin-configuration.md -> docs/psh-configuration.md
	renamed:    docs/percona-scheduler-admin-options-detail.md -> docs/psh-detailed-options.md
	renamed:    docs/percona-scheduler-admin-known-limitations.md -> docs/psh-known-limitations.md
	renamed:    docs/percona-scheduler-admin-statements-options.md -> docs/psh-options.md
	renamed:    docs/percona-scheduler-admin.md -> docs/psh-overview.md
	modified:   mkdocs-base.yml